### PR TITLE
docs: remove ZTDF references

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,13 +1,13 @@
 # OpenTDF
 
-OpenTDF is an open source system for implementing data centric security. It provides the basic services required to enable the definition, application, and enforcement of attribute based policies using the Zero Trust Data Format (ZTDF). ZTDF is an open standard that enables you to cryptographically bind attribute based access control (ABAC) policy to a data object so that the policy travels with the data wherever it goes.
+OpenTDF is an open source system for implementing data centric security. It provides the basic services required to enable the definition, application, and enforcement of attribute based policies using the Trust Data Format (TDF). TDF is an open standard that enables you to cryptographically bind attribute based access control (ABAC) policy to a data object so that the policy travels with the data wherever it goes.
 
 OpenTDF builds upon a decade of experience at Virtru protecting data objects at scale using the Trusted Data Format for organizations of all sizes and across all industries.
 
 ## Getting started
 [Platform](https://github.com/opentdf/platform): A platform that enables you to build data centric security into your applications. 
 
-[Specification](https://github.com/opentdf/spec): The TDF schema and protocol specification, fully compliant with the Zero Trust Data Format (ZTDF). 
+[Specification](https://github.com/opentdf/spec): The TDF schema and protocol specification, fully compliant with the Trusted Data Format (ZTDF). 
 
 [CLI](https://github.com/opentdf/otdfctl): A command line experience for managing an OpenTDF platform instance. 
 


### PR DESCRIPTION
Change ZTDF back to TDF. we should cover ZTDF in some way within the specification repo as an additional format that builds on top of Base TDF