### PR TITLE
docs: add link to docs.opentdf.io documentation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -5,11 +5,13 @@ OpenTDF is an open source system for implementing data centric security. It prov
 OpenTDF builds upon a decade of experience at Virtru protecting data objects at scale using the Trusted Data Format for organizations of all sizes and across all industries.
 
 ## Getting started
+[Documentation](https://docs.opentdf.io)
+
 [Platform](https://github.com/opentdf/platform): A platform that enables you to build data centric security into your applications. 
 
-[Specification](https://github.com/opentdf/spec): The TDF schema and protocol specification, fully compliant with the Trusted Data Format (ZTDF). 
+[CLI](https://github.com/opentdf/otdfctl): A command line experience for managing an OpenTDF platform instance.
 
-[CLI](https://github.com/opentdf/otdfctl): A command line experience for managing an OpenTDF platform instance. 
+[Specification](https://github.com/opentdf/spec): The TDF schema and protocol specification, fully compliant with the Trusted Data Format (ZTDF). 
 
 
 


### PR DESCRIPTION
Add a link to the docs.opentdf.io site, shuffle other links